### PR TITLE
Add support for CCS as an alternative for ConfigSpace

### DIFF
--- a/skopt/optimizer/optimizer.py
+++ b/skopt/optimizer/optimizer.py
@@ -8,7 +8,7 @@ ccs_active = False
 try:
     import cconfigspace as CCS
     ccs_active = True
-except ImportError as a:
+except (ImportError, OSError) as a:
     warnings.warn("CCS could not be loaded and is deactivated: " + str(a), category=ImportWarning)
 
 import numpy as np

--- a/skopt/optimizer/optimizer.py
+++ b/skopt/optimizer/optimizer.py
@@ -619,6 +619,8 @@ class Optimizer(object):
 
             if hasattr(self, "config_space"):
                 hps_names = self.config_space.get_hyperparameter_names()
+            elif hasattr(self, "ccs"):
+                hps_names = [x.name for x in self.ccs.hyperparameters]
             else:
                 hps_names = self.space.dimension_names
 

--- a/skopt/optimizer/optimizer.py
+++ b/skopt/optimizer/optimizer.py
@@ -9,7 +9,6 @@ try:
     import cconfigspace as CCS
     ccs_active = True
 except ImportError as a:
-    import warnings
     warnings.warn("CCS could not be loaded and is deactivated: " + str(a), category=ImportWarning)
 
 import numpy as np

--- a/skopt/optimizer/optimizer.py
+++ b/skopt/optimizer/optimizer.py
@@ -9,7 +9,8 @@ try:
     import cconfigspace as CCS
     ccs_active = True
 except ImportError as a:
-    warn("CCS could not be loaded and is deactivated: " + str(a), category=ImportWarning)
+    import warnings
+    warnings.warn("CCS could not be loaded and is deactivated: " + str(a), category=ImportWarning)
 
 import numpy as np
 import pandas as pd

--- a/skopt/optimizer/optimizer.py
+++ b/skopt/optimizer/optimizer.py
@@ -325,6 +325,7 @@ class Optimizer(object):
                 raise RuntimeError("GP estimator is not available with ConfigSpace!")
         elif ccs_active and isinstance(dimensions, CCS.ConfigurationSpace):
             self.ccs = dimensions
+            self.ccs.rng.seed = self.rng.get_state()[1][0]
 
             if isinstance(self.base_estimator_, GaussianProcessRegressor):
                 raise RuntimeError("GP estimator is not available with CCS!")

--- a/skopt/optimizer/optimizer.py
+++ b/skopt/optimizer/optimizer.py
@@ -4,7 +4,13 @@ from math import log
 from numbers import Number
 
 import ConfigSpace as CS
-import cconfigspace as CCS
+ccs_active = False
+try:
+    import cconfigspace as CCS
+    ccs_active = True
+except ImportError as a:
+    warn("CCS could not be loaded and is deactivated: " + str(a), category=ImportWarning)
+
 import numpy as np
 import pandas as pd
 
@@ -317,7 +323,7 @@ class Optimizer(object):
 
             if isinstance(self.base_estimator_, GaussianProcessRegressor):
                 raise RuntimeError("GP estimator is not available with ConfigSpace!")
-        elif type(dimensions) is CCS.ConfigurationSpace:
+        elif ccs_active and isinstance(dimensions, CCS.ConfigurationSpace):
             self.ccs = dimensions
 
             if isinstance(self.base_estimator_, GaussianProcessRegressor):

--- a/skopt/space/space.py
+++ b/skopt/space/space.py
@@ -1215,8 +1215,9 @@ class Space(object):
             points = []
             for conf in confs:
                 point = []
-                for hp in hps:
-                    val = conf.value(hp)
+                values = conf.values
+                for i, hp in enumerate(hps):
+                    val = values[i]
                     if CCS.ccs_inactive == val:
                         if self.hps_type[hp.name] == "Categorical":
                             val = "NA"

--- a/skopt/space/space.py
+++ b/skopt/space/space.py
@@ -1008,6 +1008,10 @@ class Space(object):
                     if isinstance(distrib, CCS.UniformDistribution):
                         if distrib.scale_type == CCS.ccs_scale_type.LOGARITHMIC:
                             prior = "log-uniform"
+                    elif isinstance(distrib, CCS.NormalDistribution):
+                        prior = "normal"
+                        if distrib.scale_type == CCS.ccs_scale_type.LOGARITHMIC:
+                            raise ValueError("Unsupported 'log' transformation for CCS.NumericalHyperparameter with normal prior.")
                     else:
                         raise ValueError("Unsupported distribution")
                     if CCS.ccs_numeric_type.NUM_INTEGER:

--- a/skopt/space/space.py
+++ b/skopt/space/space.py
@@ -979,7 +979,7 @@ class Space(object):
                 else:
                     raise ValueError("Unknown Hyperparameter type.")
             dimensions = space
-        elif ccs_active && isinstance(dimensions, CCS.ConfigurationSpace):
+        elif ccs_active & isinstance(dimensions, CCS.ConfigurationSpace):
             self.is_ccs = True
             self.ccs = dimensions
             self.hps_type = {}

--- a/skopt/space/space.py
+++ b/skopt/space/space.py
@@ -994,7 +994,7 @@ class Space(object):
                         vals.append("NA")
                     if isinstance(distrib, CCS.RouletteDistribution):
                         param = Categorical(vals, prior=distrib.areas, name=x.name)
-                    elif sinstance(distrib, CCS.UniformDistribution):
+                    elif isinstance(distrib, CCS.UniformDistribution):
                         param = Categorical(vals, name=x.name)
                     else:
                         raise ValueError("Unsupported distribution")
@@ -1211,7 +1211,7 @@ class Space(object):
                 point = []
                 for hp in hps:
                     val = conf.value(hp)
-                    if ccs.ccs_inactive == val:
+                    if CCS.ccs_inactive == val:
                         if self.hps_type[hp.name] == "Categorical":
                             val = "NA"
                         else:

--- a/skopt/space/space.py
+++ b/skopt/space/space.py
@@ -34,7 +34,7 @@ ccs_active = False
 try:
     import cconfigspace as CCS
     ccs_active = True
-except ImportError as a:
+except (ImportError, OSError) as a:
     import warnings
     warnings.warn("CCS could not be loaded and is deactivated: " + str(a), category=ImportWarning)
 

--- a/skopt/space/space.py
+++ b/skopt/space/space.py
@@ -35,7 +35,8 @@ try:
     import cconfigspace as CCS
     ccs_active = True
 except ImportError as a:
-    warn("CCS could not be loaded and is deactivated: " + str(a), category=ImportWarning)
+    import warnings
+    warnings.warn("CCS could not be loaded and is deactivated: " + str(a), category=ImportWarning)
 
 from sklearn.impute import SimpleImputer
 

--- a/skopt/space/space.py
+++ b/skopt/space/space.py
@@ -30,6 +30,7 @@ from .transformers import ToInteger
 
 import ConfigSpace as CS
 from ConfigSpace.util import deactivate_inactive_hyperparameters
+import cconfigspace as CCS
 
 from sklearn.impute import SimpleImputer
 
@@ -896,8 +897,11 @@ class Space(object):
 
         # attributes used when a ConfigurationSpace from ConfigSpace is given
         self.is_config_space = False
+        self.is_ccs = False
         self.config_space_samples = None
+        self.ccs_samples = None
         self.config_space_explored = False
+        self.ccs_explored = False
 
         self.imp_const = SimpleImputer(
             missing_values=np.nan, strategy="constant", fill_value=-1000
@@ -969,6 +973,52 @@ class Space(object):
                     self.hps_type[x.name] = "Real"
                 else:
                     raise ValueError("Unknown Hyperparameter type.")
+            dimensions = space
+        elif isinstance(dimensions, CCS.ConfigurationSpace):
+            self.is_ccs = True
+            self.ccs = dimensions
+            self.hps_type = {}
+
+            hps = self.ccs.hyperparameters
+            cond_hps = [x.name for x in self.ccs.conditional_hyperparameters]
+
+            space = []
+            for x in hps:
+                self.hps_names.append(x.name)
+                distrib = self.ccs.get_hyperparameter_distribution(x)[0]
+                if (isinstance(x, CCS.CategoricalHyperparameter) or
+                        isinstance(x, CCS.OrdinalHyperparameter) or
+                        isinstance(x, CCS.DiscreteHyperparameter)):
+                    vals = list(x.values)
+                    if x.name in cond_hps:
+                        vals.append("NA")
+                    if isinstance(distrib, CCS.RouletteDistribution):
+                        param = Categorical(vals, prior=distrib.areas, name=x.name)
+                    elif sinstance(distrib, CCS.UniformDistribution):
+                        param = Categorical(vals, name=x.name)
+                    else:
+                        raise ValueError("Unsupported distribution")
+                    space.append(param)
+                    self.hps_type[x.name] = "Categorical"
+                elif isinstance(x, CCS.NumericalHyperparameter):
+                    prior = "uniform"
+                    lower = x.lower
+                    upper = x.upper
+                    t = x.data_type
+                    if isinstance(distrib, CCS.UniformDistribution):
+                        if distrib.scale_type == CCS.ccs_scale_type.LOGARITHMIC:
+                            prior = "log-uniform"
+                    else:
+                        raise ValueError("Unsupported distribution")
+                    if CCS.ccs_numeric_type.NUM_INTEGER:
+                        param = Integer(lower, upper, prior=prior, name=x.name)
+                        self.hps_type[x.name] = "Integer"
+                    else:
+                        param = Real(lower, upper, prior=prior, name=x.name)
+                        self.hps_type[x.name] = "Real"
+                    space.append(param)
+                else:
+                    raise ValueError("Unknown Hyperparameter type")
             dimensions = space
         self.dimensions = [check_dimension(dim) for dim in dimensions]
 
@@ -1149,6 +1199,23 @@ class Space(object):
                 req_points.append(point)
 
             return req_points
+        elif self.is_ccs:
+            confs = self.ccs.samples(n_samples)
+            hps = self.ccs.hyperparameters
+            points = []
+            for conf in confs:
+                point = []
+                for hp in hps:
+                    val = conf.value(hp)
+                    if ccs.ccs_inactive == val:
+                        if self.hps_type[hp.name] == "Categorical":
+                            val = "NA"
+                        else:
+                            val = np.nan
+                    point.append(val)
+                points.append(point)
+
+            return points
         else:
             if self.model_sdv is None:
                 # Draw
@@ -1240,7 +1307,7 @@ class Space(object):
         # Repack as an array
         Xt = np.hstack([np.asarray(c).reshape((len(X), -1)) for c in columns])
 
-        if False and self.is_config_space:
+        if False and (self.is_config_space or self.is_ccs):
             self.imp_const.fit(Xt)
             Xtt = self.imp_const.transform(Xt)
             Xt = Xtt

--- a/skopt/space/space.py
+++ b/skopt/space/space.py
@@ -30,7 +30,12 @@ from .transformers import ToInteger
 
 import ConfigSpace as CS
 from ConfigSpace.util import deactivate_inactive_hyperparameters
-import cconfigspace as CCS
+ccs_active = False
+try:
+    import cconfigspace as CCS
+    ccs_active = True
+except ImportError as a:
+    warn("CCS could not be loaded and is deactivated: " + str(a), category=ImportWarning)
 
 from sklearn.impute import SimpleImputer
 
@@ -974,7 +979,7 @@ class Space(object):
                 else:
                     raise ValueError("Unknown Hyperparameter type.")
             dimensions = space
-        elif isinstance(dimensions, CCS.ConfigurationSpace):
+        elif ccs_active && isinstance(dimensions, CCS.ConfigurationSpace):
             self.is_ccs = True
             self.ccs = dimensions
             self.hps_type = {}

--- a/skopt/space/space.py
+++ b/skopt/space/space.py
@@ -980,7 +980,7 @@ class Space(object):
                 else:
                     raise ValueError("Unknown Hyperparameter type.")
             dimensions = space
-        elif ccs_active & isinstance(dimensions, CCS.ConfigurationSpace):
+        elif ccs_active and isinstance(dimensions, CCS.ConfigurationSpace):
             self.is_ccs = True
             self.ccs = dimensions
             self.hps_type = {}


### PR DESCRIPTION
This adds support for CCS using it's Python bindings, and can be used as a replacement for ConfigSpace.
No dependencies are added as the support is strictly optional and can only print a warning (if those are activated) should either the binding or the library be missing from the system.

CCS is an ECP ProteasTune component, more information here: https://github.com/argonne-lcf/CCS/
